### PR TITLE
docs: add GitHub comment formatting rule

### DIFF
--- a/dotfiles/CLAUDE.md
+++ b/dotfiles/CLAUDE.md
@@ -61,6 +61,12 @@ Follow the session startup checklist before beginning work.
 - Good: `Tool`, `RemoteTool`, `Registry`, `execute()`
 - Bad: `AbstractToolInterface`, `MCPToolWrapper`, `ToolRegistryManager`
 
+## GitHub Comments
+
+- NEVER use `#N` in PR or issue comments — GitHub auto-links `#1`, `#2` etc.
+  to issue numbers. Use parenthesised numbers `(1)`, `(2)` or plain numbered
+  lists instead
+
 ## Version Control
 
 - If no git repo exists, STOP and ask permission to initialise one

--- a/dotfiles/CLAUDE.md
+++ b/dotfiles/CLAUDE.md
@@ -63,7 +63,7 @@ Follow the session startup checklist before beginning work.
 
 ## GitHub Comments
 
-- NEVER use `#N` in PR or issue comments — GitHub auto-links `#1`, `#2` etc.
+- NEVER use numbered references like `#1` and `#2` in PR or issue comments — GitHub auto-links them
   to issue numbers. Use parenthesised numbers `(1)`, `(2)` or plain numbered
   lists instead
 


### PR DESCRIPTION
## Summary

- Adds a GitHub Comments section to the CLAUDE.md dotfile template
- Rule prevents using `#N` in PR or issue comments, since GitHub auto-links these to issue numbers
- Recommends parenthesised numbers `(1)`, `(2)` or plain numbered lists instead

## Context

Discovered during PR reviews on the motel project where numbered references like `#1`, `#2` in review comments were auto-linked to unrelated GitHub issues.

## Test plan

- [ ] Verify the rule appears in the GitHub Comments section of the dotfiles CLAUDE.md template